### PR TITLE
Fix rollback migration

### DIFF
--- a/database/migrations/create_custom_fields_tables.php.stub
+++ b/database/migrations/create_custom_fields_tables.php.stub
@@ -38,7 +38,7 @@ class CreateCustomFieldsTables extends Migration
 
     public function down()
     {
-        Schema::dropIfExists(config('custom-fields.tables.fields', 'custom_fields'));
         Schema::dropIfExists(config('custom-fields.tables.field_responses', 'custom_field_responses'));
+        Schema::dropIfExists(config('custom-fields.tables.fields', 'custom_fields'));
     }
 }


### PR DESCRIPTION
When we call the migration:rollback command, an error occurs due to the dependence of the tables